### PR TITLE
Cambio hacia nueva versión utilizando ViewModel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Imagenes de mi lab: ![Imagen de WhatsApp 2025-09-28 a las 22 07 14_dc658f72](https://github.com/user-attachments/assets/f20cc89a-3cc7-48f0-8961-9533befd3ddf)
+![Imagen de WhatsApp 2025-09-28 a las 22 07 14_43c0cc79](https://github.com/user-attachments/assets/64c0b6b4-7f23-42f0-95c9-39abcf1020f4)
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,4 +67,7 @@ dependencies {
     implementation(libs.coil.compose)
     //navigation
     implementation(libs.androidx.navigation.compose)
+    //viewmodel
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Lab5pokemon">
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Lab5pokemon">

--- a/app/src/main/java/com/example/lab5_pokemon/data/remote/ApiService.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/data/remote/ApiService.kt
@@ -1,5 +1,6 @@
-package com.example.lab5_pokemon.network
+package com.example.lab5_pokemon.data.remote
 
+import com.example.lab5_pokemon.data.remote.dto.PokemonListResponse
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
@@ -7,18 +8,6 @@ import retrofit2.http.Query
 
 private const val BASE_URL = "https://pokeapi.co/api/v2/"
 
-// Modelo de cada Pokémon en la respuesta
-data class PokemonResult(
-    val name: String,
-    val url: String
-)
-
-// Nuevo nombre para la respuesta de la API
-data class PokemonListResponse(
-    val results: List<PokemonResult>
-)
-
-// Interfaz Retrofit: define la llamada a la API
 interface PokeApiService {
     @GET("pokemon")
     suspend fun getPokemonList(
@@ -27,9 +16,8 @@ interface PokeApiService {
     ): PokemonListResponse
 }
 
-// Objeto singleton para acceder al servicio Retrofit desde cualquier parte de la app
-object PokeApi {
-    val retrofitService: PokeApiService by lazy {
+object RetrofitClient {
+    val apiService: PokeApiService by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())

--- a/app/src/main/java/com/example/lab5_pokemon/data/remote/dto/PokemonDto.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/data/remote/dto/PokemonDto.kt
@@ -1,0 +1,10 @@
+package com.example.lab5_pokemon.data.remote.dto
+
+data class PokemonListResponse(
+    val results: List<PokemonResultDto>
+)
+
+data class PokemonResultDto(
+    val name: String,
+    val url: String
+)

--- a/app/src/main/java/com/example/lab5_pokemon/data/repository/PokemonRepository.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/data/repository/PokemonRepository.kt
@@ -1,0 +1,21 @@
+package com.example.lab5_pokemon.data.repository
+
+import com.example.lab5_pokemon.data.remote.RetrofitClient
+import com.example.lab5_pokemon.domain.model.Pokemon
+
+class PokemonRepository {
+    private val apiService = RetrofitClient.apiService
+
+    suspend fun getPokemonList(): Result<List<Pokemon>> {
+        return try {
+            val response = apiService.getPokemonList()
+            val pokemonList = response.results.map { dto ->
+                val id = dto.url.trimEnd('/').split('/').last()
+                Pokemon(name = dto.name, id = id)
+            }
+            Result.success(pokemonList)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/example/lab5_pokemon/domain/model/Pokemon.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/domain/model/Pokemon.kt
@@ -1,34 +1,18 @@
-package com.example.lab5_pokemon.network
+package com.example.lab5_pokemon.domain.model
 
-// Modelo de respuesta de la API
-data class PokeResponse(
-    val results: List<PokemonApi>
-)
-
-// Cada Pokémon que viene de la API
-data class PokemonApi(
-    val name: String,
-    val url: String
-)
-
-// Clase modelo de Pokémon en la app
 data class Pokemon(
     val name: String,
     val id: String
 ) {
-    // URL para la imagen frontal normal
     val imageUrlFront: String
         get() = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/$id.png"
 
-    // URL para la imagen trasera normal
     val imageUrlBack: String
         get() = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/$id.png"
 
-    // URL para la imagen frontal shiny
     val imageUrlShinyFront: String
         get() = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/$id.png"
 
-    // URL para la imagen trasera shiny
     val imageUrlShinyBack: String
         get() = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/$id.png"
 }

--- a/app/src/main/java/com/example/lab5_pokemon/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/ui/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.lab5_pokemon
+package com.example.lab5_pokemon.ui
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.example.lab5_pokemon.ui.detail.PokemonDetailScreen
+import com.example.lab5_pokemon.ui.list.PokemonListScreen
 import com.example.lab5_pokemon.ui.theme.Lab5pokemonTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,7 +23,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             Lab5pokemonTheme {
                 Surface(
-                    modifier = androidx.compose.ui.Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
                     PokemonApp() // Aquí iniciaremos nuestra app con navegación

--- a/app/src/main/java/com/example/lab5_pokemon/ui/detail/PokemonDetailScreen.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/ui/detail/PokemonDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.example.lab5_pokemon
+package com.example.lab5_pokemon.ui.detail
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
-import com.example.lab5_pokemon.network.Pokemon
+import com.example.lab5_pokemon.domain.model.Pokemon
 import java.util.Locale
 
 @Composable

--- a/app/src/main/java/com/example/lab5_pokemon/ui/list/PokemonListScreen.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/ui/list/PokemonListScreen.kt
@@ -1,54 +1,70 @@
-package com.example.lab5_pokemon
+package com.example.lab5_pokemon.ui.list
+
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import coil.compose.rememberAsyncImagePainter
-import com.example.lab5_pokemon.network.Pokemon
-import com.example.lab5_pokemon.network.PokeApi
-import kotlinx.coroutines.launch
+import com.example.lab5_pokemon.domain.model.Pokemon
 import java.util.Locale
 
 @Composable
-fun PokemonListScreen(navController: NavHostController) {
-    var pokemonList by remember { mutableStateOf<List<Pokemon>>(emptyList()) }
-    val coroutineScope = rememberCoroutineScope()
-
-    LaunchedEffect(Unit) {
-        coroutineScope.launch {
-            try {
-                val response = PokeApi.retrofitService.getPokemonList()
-                pokemonList = response.results.map { poke ->
-                    val id = poke.url.trimEnd('/').split('/').last()
-                    Pokemon(name = poke.name, id = id)
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-    }
+fun PokemonListScreen(
+    navController: NavHostController,
+    viewModel: PokemonListViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
 
     Column(Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Pokémon List",
+        Text(
+            "Pokémon List",
             style = MaterialTheme.typography.headlineMedium,
             modifier = Modifier.padding(top = 16.dp)
-            )
+        )
         Spacer(modifier = Modifier.height(8.dp))
 
-        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            items(pokemonList) { pokemon ->
-                PokemonCard(pokemon, navController)
+        when {
+            uiState.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            uiState.errorMessage != null -> {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = uiState.errorMessage ?: "Error desconocido",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = { viewModel.retry() }) {
+                        Text("Reintentar")
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.pokemonList) { pokemon ->
+                        PokemonCard(pokemon, navController)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/lab5_pokemon/ui/list/PokemonListViewModel.kt
+++ b/app/src/main/java/com/example/lab5_pokemon/ui/list/PokemonListViewModel.kt
@@ -1,0 +1,51 @@
+package com.example.lab5_pokemon.ui.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.lab5_pokemon.data.repository.PokemonRepository
+import com.example.lab5_pokemon.domain.model.Pokemon
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class PokemonListUiState(
+    val pokemonList: List<Pokemon> = emptyList(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class PokemonListViewModel : ViewModel() {
+    private val repository = PokemonRepository()
+
+    private val _uiState = MutableStateFlow(PokemonListUiState())
+    val uiState: StateFlow<PokemonListUiState> = _uiState.asStateFlow()
+
+    init {
+        loadPokemonList()
+    }
+
+    private fun loadPokemonList() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+
+            repository.getPokemonList()
+                .onSuccess { pokemonList ->
+                    _uiState.value = _uiState.value.copy(
+                        pokemonList = pokemonList,
+                        isLoading = false
+                    )
+                }
+                .onFailure { exception ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = "Error: ${exception.message}"
+                    )
+                }
+        }
+    }
+
+    fun retry() {
+        loadPokemonList()
+    }
+}


### PR DESCRIPTION
Cambios: 
Refactoricé el código del Lab 5 para seguir el patrón MVVM (Model-View-ViewModel) con una arquitectura limpia y organizada. El objetivo fue separar mejor las responsabilidades del código para que sea más fácil de mantener y escalar.

Ahora el proyecto tiene tres capas principales:
- UI
Basicamente lo que teniamos de la lista y los detalles de Pokemon, pero ahora pokemonlistscreen solo se encarga de mostrar los datos, no obtenerlos y el pokemonlistviewmodel maneja la lógica por medio de stateflow.
- Dominio
Se encuentra el modelo que representa a un pokemon en la aplicación.
- Capa de datos
Se encuentra todo lo relacionado con obtener datos externos, el PokemonRepository es el intermediario y en ApiService está la configuracipin con Retrofit.

